### PR TITLE
:bug: fix Rapid Trigger config not loaded from device

### DIFF
--- a/ember-web-configurator/src/app/page.tsx
+++ b/ember-web-configurator/src/app/page.tsx
@@ -588,7 +588,7 @@ export default function Home() {
           next[keyId] = {
             ...baseDefaults,
             keyCode: config.keyCode ?? baseDefaults.keyCode ?? null,
-            rapidTrigger: config.keyType === 1,
+            rapidTrigger: config.keyType === 3,
             actuationPoint: roundToTenth(config.actuationPointMm),
             rapidTriggerUpSensitivity: roundToTenth(config.rapidTriggerUpSensitivityMm),
             rapidTriggerDownSensitivity: roundToTenth(config.rapidTriggerDownSensitivityMm),
@@ -721,7 +721,7 @@ export default function Home() {
           actuationPoint: roundToTenth(config.actuationPointMm),
           rapidTriggerUpSensitivity: roundToTenth(config.rapidTriggerUpSensitivityMm),
           rapidTriggerDownSensitivity: roundToTenth(config.rapidTriggerDownSensitivityMm),
-          rapidTrigger: config.keyType === 1,
+          rapidTrigger: config.keyType === 3,
         });
       } catch (err) {
         console.error(`Failed to load key config for key ${selectedKey}:`, err);


### PR DESCRIPTION
## Summary
- デバイスからRapid Trigger設定を読み込む際、`keyType === 1`（CALIBRATE）と比較していたため、`keyType === 3`（RAPID_TRIGGER）の正しい値が常に`false`と判定されていた
- 設定を保存した後にWebUIを再度開くと、Rapid Triggerが常に無効として表示されるバグを修正
- 2箇所（全キー一括読み込み・キー選択時の個別読み込み）を`=== 3`に修正

## Test plan
- [ ] Rapid Triggerを有効にして保存し、WebUIを再度開いたときにRapid Triggerが有効として表示されることを確認
- [ ] Rapid Triggerを無効にして保存し、再度開いたときに無効として表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)